### PR TITLE
user option enforces permissions for WRITE operations

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -380,6 +380,17 @@ WebHDFSProxyServer.prototype._validateRequest = function validateRequest (operat
 };
 
 /**
+ * Stops the servers from accepting new connections
+ *
+ * @param {Function} done
+ */
+WebHDFSProxyServer.prototype.close = function close (done) {
+  async.each(this._servers, function close (server, done) {
+    return server.close(done);
+  }, done);
+}
+
+/**
  * Middleware handler function
  *
  * @callback WebHDFSProxyServer~MiddlewareHandler

--- a/lib/server.js
+++ b/lib/server.js
@@ -287,7 +287,9 @@ WebHDFSProxyServer.prototype._handleRequest = function handleRequest (req, res, 
     if (this._validate) {
       this._validateRequest(operation, params, function requestValidated (err) {
         if (err) {
-          if (err.code && err.code === 'MODULE_NOT_FOUND') {
+          if (err instanceof APIError) {
+            self._handler(err, path, operation, params, req, res, done);
+          } else if (err.code && err.code === 'MODULE_NOT_FOUND') {
             self._handler(
               new APIError('RuntimeException', {
                 message: 'Unable to validate request path: ' + req.url
@@ -358,6 +360,15 @@ WebHDFSProxyServer.prototype._validateRequest = function validateRequest (operat
     function validateParams (schema, next) {
       var result = tv4.validateResult(params, schema);
       if (result.valid) {
+        if (operation === 'create' || operation === 'append' || operation === 'delete' ||
+            operation === 'setowner' || operation === 'setpermission' || operation === 'rename' ||
+            operation === 'createsymlink' || operation === 'mkdirs') {
+          if (self._opts.user && self._opts.user !== params['user.name']) {
+            return next(new APIError('SecurityException', {
+              message: 'user=' + params['user.name'] + ', access=WRITE'
+            }));
+          }
+        }
         return next();
       } else {
         return next(result.error);

--- a/test/server.js
+++ b/test/server.js
@@ -50,6 +50,7 @@ describe('WebHDFS Proxy', function () {
   var path = null;
   var opts = {
     path: '/webhdfs/v1',
+    user: 'webuser',
     http: {
       port: 45000
     },
@@ -73,6 +74,15 @@ describe('WebHDFS Proxy', function () {
           demand(err).be.null();
           demand(handler.calledWithMatch(null, path, 'mkdirs', { op: 'mkdirs', 'user.name': 'webuser', permissions: '0777' })).be.truthy();
 
+          return done();
+        });
+      });
+
+      it('should succeed if supported write operation with wrong user returned an error', function (done) {
+        client._opts.user = 'wronguser';
+        client.mkdir(path, function (err) {
+          demand(err).not.be.null();
+          client._opts.user = 'webuser';
           return done();
         });
       });

--- a/test/server.js
+++ b/test/server.js
@@ -63,6 +63,10 @@ describe('WebHDFS Proxy', function () {
     proxyServer = WebHDFSProxy.createServer(opts, handler, done);
   });
 
+  after(function (done) {
+    proxyServer.close(done);
+  });
+
   function createTests (title, client) {
     describe(title, function () {
       before(function () {


### PR DESCRIPTION
Hi!

In order to make webhdfs-proxy behave just like my local hadoop installation with regard to writes,
I added an optional `user` option.
When specified write operations will refuse to execute if the user parameter in the request does not match.

I hope this helps.